### PR TITLE
Add a pre-check to avoid segfault with null 1st parameter adress

### DIFF
--- a/ft_printf.c
+++ b/ft_printf.c
@@ -46,6 +46,8 @@ int		ft_printf(const char *string, ...)
 	int		i;
 	int		printed;
 
+	if (string == NULL)
+		return (-1);
 	va_start(args, string);
 	i = 0;
 	printed = 0;
@@ -54,10 +56,7 @@ int		ft_printf(const char *string, ...)
 		if (string[i] == '%')
 			printed += func_branch(string, &i, args);
 		else
-		{
-			write(1, &string[i++], 1);
-			printed++;
-		}
+			printed += write(1, &string[i++], 1);
 	}
 	va_end(args);
 	return (printed);


### PR DESCRIPTION
The printf function of most OSes will return -1 if the first argument has a null adress. So, I put this case aside with a pre-check in the ft_printf function, just before the while loop, to don't browse into a null string (segfault).
The part of code added :
```
	if (string == NULL)
		return (-1);
```

By the way, I turned `write(1, &string[i++], 1); printed++;` into `printed += write(1, &string[i++], 1);`, in the ft_printf function, to simply use the write return value for the printed variable incrementation. 